### PR TITLE
Feat/#7 Todo 페이지 노트 영역 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
     "styled-components": "^5.3.6",
-    "styled-reset": "^4.4.2"
+    "styled-reset": "^4.4.2",
+    "vite-plugin-svgr": "^2.2.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.24",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { GlobalStyle } from './styles/global';
 import Router from './components/router';
+import Layout from './components/Layout';
 
 function App() {
   return (
-    <>
+    <Layout>
       <GlobalStyle />
       <Router />
-    </>
+    </Layout>
   );
 }
 

--- a/src/assets/iOption.svg
+++ b/src/assets/iOption.svg
@@ -1,0 +1,12 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_2964_32091)">
+<circle cx="7.5" cy="10.5" r="1.5" fill="#111111"/>
+<circle cx="12.5" cy="10.5" r="1.5" fill="#111111"/>
+<circle cx="17.5" cy="10.5" r="1.5" fill="#111111"/>
+</g>
+<defs>
+<clipPath id="clip0_2964_32091">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/iPlus.svg
+++ b/src/assets/iPlus.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.5 17V11.5M11.5 11.5V6M11.5 11.5H17M11.5 11.5H6" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function Header() {
-  return <div>Header</div>;
-}
-
-export default Header;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+function Layout({ children }) {
+  return <Main>{children}</Main>;
+}
+
+export default Layout;
+
+const Main = styled.main`
+  margin: 0 2.4rem;
+`;

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -75,13 +75,13 @@ function NoteList() {
 
 function BoardItem() {
   return (
-    <StPinImageWrapper>
+    <StyledBoardItemWrapper>
       {Array.from({ length: 3 }, (_v, i) => i).map((idx) => (
-        <StImageWrapper key={idx} idx={idx}>
+        <StyledBoardItem key={idx} idx={idx}>
           <div></div>
-        </StImageWrapper>
+        </StyledBoardItem>
       ))}
-    </StPinImageWrapper>
+    </StyledBoardItemWrapper>
   );
 }
 
@@ -157,7 +157,7 @@ const StyledNoteInfo = styled.div`
   color: ${pinterestColors.gray400};
 `;
 
-const StPinImageWrapper = styled.article`
+const StyledBoardItemWrapper = styled.article`
   display: grid;
   grid-template-columns: 16.8rem;
   grid-template-rows: 9.5rem 9.3rem;
@@ -166,7 +166,7 @@ const StPinImageWrapper = styled.article`
   margin-top: 2.2rem;
 `;
 
-const StImageWrapper = styled.div`
+const StyledBoardItem = styled.div`
   height: 18.8rem;
   background-color: #d9d9d9;
 

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -47,24 +47,22 @@ function NoteList() {
 
       <StyledNoteList>
         {noteList.map(({ title, date, todo }, idx) => (
-          <StyledNote
-            key={title}
-            onClick={(e) => toggleNoteStatus(e, idx)}
-            status={noteStatus[idx]}
-          >
+          <StyledNote key={title} status={noteStatus[idx]}>
             {openDropBox[idx] && <DropBox text={dropBoxData.text} options={dropBoxData.options} />}
-            <StyledTitle>
-              <h1>{title}</h1>
-              <div id="option">
-                <IOption onClick={() => openOptionModal(idx)} />
-              </div>
-            </StyledTitle>
+            <div onClick={(e) => toggleNoteStatus(e, idx)}>
+              <StyledTitle>
+                <h1>{title}</h1>
+                <div id="option">
+                  <IOption onClick={() => openOptionModal(idx)} />
+                </div>
+              </StyledTitle>
 
-            <StyledNoteInfo>
-              <span>
-                {date} &#183; {todo}
-              </span>
-            </StyledNoteInfo>
+              <StyledNoteInfo>
+                <span>
+                  {date} &#183; {todo}
+                </span>
+              </StyledNoteInfo>
+            </div>
           </StyledNote>
         ))}
       </StyledNoteList>

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { pinterestColors } from '../styles/color';
 import { ReactComponent as IPlus } from '../assets/iPlus.svg';
 import { ReactComponent as IOption } from '../assets/iOption.svg';
 import { Link } from 'react-router-dom';
+import DropBox from '../components/common/DropBox';
 
 const noteList = [
   { title: '제목1', date: '2022년 11월 14일 (월)', todo: '할 일 2개' },
@@ -14,10 +15,25 @@ const noteList = [
 
 function NoteList() {
   const [noteStatus, setNoteStatus] = useState(new Array(noteList.length).fill(false));
-  const toggleNoteStatus = (idx) => {
+  const [openModal, setOpenModal] = useState(new Array(noteList.length).fill(false));
+
+  const toggleNoteStatus = (e, idx) => {
+    if (e.target.closest('div').id === 'option') return;
+    changeStatus(idx, noteStatus, setNoteStatus);
+  };
+
+  const openOptionModal = (idx) => {
+    changeStatus(idx, openModal, setOpenModal);
+  };
+
+  const changeStatus = (idx, array, handler) => {
     let newStatus = new Array(noteList.length).fill(false);
+    if (array.some((val) => val)) {
+      handler(newStatus);
+      return;
+    }
     newStatus[idx] = !newStatus[idx];
-    setNoteStatus(newStatus);
+    handler(newStatus);
   };
 
   return (
@@ -28,34 +44,29 @@ function NoteList() {
       </StyledCreateButton>
 
       <StyledNoteList>
-        {noteList.map((note, idx) => (
-          <Note
-            key={note.title}
-            note={note}
-            noteStatus={noteStatus[idx]}
-            onClick={() => toggleNoteStatus(idx)}
-          />
+        {noteList.map(({ title, date, todo }, idx) => (
+          <StyledNote
+            key={title}
+            onClick={(e) => toggleNoteStatus(e, idx)}
+            status={noteStatus[idx]}
+          >
+            {openModal[idx] && <DropBox />}
+            <StyledTitle>
+              <h1>{title}</h1>
+              <div id="option">
+                <IOption onClick={() => openOptionModal(idx)} />
+              </div>
+            </StyledTitle>
+
+            <StyledNoteInfo>
+              <span>
+                {date} &#183; {todo}
+              </span>
+            </StyledNoteInfo>
+          </StyledNote>
         ))}
       </StyledNoteList>
     </StyledRoot>
-  );
-}
-
-function Note(props) {
-  const { note, noteStatus, onClick } = props;
-  const { title, date, todo } = note;
-  return (
-    <StyledNote onClick={onClick} status={noteStatus}>
-      <StyledTitle>
-        <h1>{title}</h1>
-        <IOption />
-      </StyledTitle>
-      <StyledNoteInfo>
-        <span>
-          {date} &#183; {todo}
-        </span>
-      </StyledNoteInfo>
-    </StyledNote>
   );
 }
 

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -119,7 +119,8 @@ const StyledNote = styled.div`
     `}
 
   &:not(:last-child) {
-    border-bottom: ${({ status }) => !status && '1.25px solid #e9e9e9'};
+    border-bottom: ${({ status }) =>
+      !status ? '1.25px solid #e9e9e9' : '1.25px solid rgba(0,0,0,0)'};
   }
 `;
 

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import styled from 'styled-components';
+import { pinterestColors } from '../styles/color';
+import { ReactComponent as IPlus } from '../assets/iPlus.svg';
+import { ReactComponent as IOption } from '../assets/iOption.svg';
+
+function NoteList() {
+  return (
+    <StyledRoot>
+      <StyledCreateButton>
+        <h1>노트 만들기</h1>
+        <IPlus />
+      </StyledCreateButton>
+
+      <StyledNoteList>
+        <Note />
+      </StyledNoteList>
+    </StyledRoot>
+  );
+}
+
+function Note() {
+  return (
+    <StyledNote>
+      <StyledTitle>
+        <h1>제목 영역</h1>
+        <IOption />
+      </StyledTitle>
+      <StyledNoteInfo>
+        <span>2022년 11월 14일 (월)</span>
+      </StyledNoteInfo>
+    </StyledNote>
+  );
+}
+
+export default NoteList;
+
+const StyledRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 33.8rem;
+  overflow-y: scroll;
+`;
+
+const StyledCreateButton = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.6rem 2rem;
+  border: 1px solid #efefef;
+  border-radius: 1rem;
+  margin-bottom: 3rem;
+
+  & > h1 {
+    font-weight: 700;
+    font-size: 1.6rem;
+    line-height: 1.9rem;
+    color: ${pinterestColors.black};
+  }
+`;
+
+const StyledNoteList = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledNote = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 2.2rem 2rem 2.2rem;
+  border-bottom: 1.25px solid #e9e9e9;
+`;
+
+const StyledTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  & > h1 {
+    font-weight: 700;
+    font-size: 1.6rem;
+    line-height: 1.9rem;
+    color: ${pinterestColors.black};
+  }
+`;
+
+const StyledNoteInfo = styled.div`
+  display: flex;
+  & > span {
+    font-weight: 400;
+    font-size: 1.4rem;
+    line-height: 1.7rem;
+    color: ${pinterestColors.gray400};
+  }
+`;

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -4,6 +4,13 @@ import { pinterestColors } from '../styles/color';
 import { ReactComponent as IPlus } from '../assets/iPlus.svg';
 import { ReactComponent as IOption } from '../assets/iOption.svg';
 
+const noteList = [
+  { title: '제목1', date: '2022년 11월 14일 (월)', todo: '할 일 2개' },
+  { title: '제목2', date: '2022년 11월 14일 (월)', todo: '할 일 2개' },
+  { title: '제목3', date: '2022년 11월 14일 (월)', todo: '할 일 2개' },
+  { title: '제목4', date: '2022년 11월 14일 (월)', todo: '할 일 2개' },
+];
+
 function NoteList() {
   return (
     <StyledRoot>
@@ -13,21 +20,26 @@ function NoteList() {
       </StyledCreateButton>
 
       <StyledNoteList>
-        <Note />
+        {noteList.map((note) => (
+          <Note key={note.title} note={note} />
+        ))}
       </StyledNoteList>
     </StyledRoot>
   );
 }
 
-function Note() {
+function Note({ note }) {
+  const { title, date, todo } = note;
   return (
     <StyledNote>
       <StyledTitle>
-        <h1>제목 영역</h1>
+        <h1>{title}</h1>
         <IOption />
       </StyledTitle>
       <StyledNoteInfo>
-        <span>2022년 11월 14일 (월)</span>
+        <span>
+          {date} &#183; {todo}
+        </span>
       </StyledNoteInfo>
     </StyledNote>
   );
@@ -50,6 +62,7 @@ const StyledCreateButton = styled.div`
   border: 1px solid #efefef;
   border-radius: 1rem;
   margin-bottom: 3rem;
+  cursor: pointer;
 
   & > h1 {
     font-weight: 700;
@@ -68,7 +81,12 @@ const StyledNote = styled.div`
   display: flex;
   flex-direction: column;
   padding: 0 2.2rem 2rem 2.2rem;
-  border-bottom: 1.25px solid #e9e9e9;
+  cursor: pointer;
+
+  &:not(:last-child) {
+    border-bottom: 1.25px solid #e9e9e9;
+    margin-bottom: 1.6rem;
+  }
 `;
 
 const StyledTitle = styled.div`

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -16,8 +16,8 @@ const noteList = [
 const dropBoxData = { text: '노트 옵션', options: ['삭제', '수정'] };
 
 function NoteList() {
-  const [noteStatus, setNoteStatus] = useState(new Array(noteList.length).fill(false));
-  const [openDropBox, setOpenDropBox] = useState(new Array(noteList.length).fill(false));
+  const [noteStatus, setNoteStatus] = useState(new Array(noteList.length).fill('close'));
+  const [dropBoxStatus, setDropBoxStatus] = useState(new Array(noteList.length).fill('close'));
 
   const toggleNoteStatus = (e, idx) => {
     if (e.target.closest('div').id === 'option') return;
@@ -25,16 +25,16 @@ function NoteList() {
   };
 
   const openOptionModal = (idx) => {
-    changeStatus(idx, openDropBox, setOpenDropBox);
+    changeStatus(idx, dropBoxStatus, setDropBoxStatus);
   };
 
   const changeStatus = (idx, array, handler) => {
-    let newStatus = new Array(noteList.length).fill(false);
-    if (array.some((val) => val) && array.indexOf(true) === idx) {
+    let newStatus = new Array(noteList.length).fill('close');
+    if (array.some((val) => val) && array.indexOf('open') === idx) {
       handler(newStatus);
       return;
     }
-    newStatus[idx] = !newStatus[idx];
+    newStatus[idx] = newStatus[idx] === 'open' ? 'close' : 'open';
     handler(newStatus);
   };
 
@@ -47,8 +47,11 @@ function NoteList() {
 
       <StyledNoteList>
         {noteList.map(({ title, date, todo }, idx) => (
-          <StyledNote key={title} status={noteStatus[idx]}>
-            {openDropBox[idx] && <DropBox text={dropBoxData.text} options={dropBoxData.options} />}
+          <StyledNote key={title} isOpen={noteStatus[idx] === 'open'}>
+            {dropBoxStatus[idx] === 'open' && (
+              <DropBox text={dropBoxData.text} options={dropBoxData.options} />
+            )}
+
             <div onClick={(e) => toggleNoteStatus(e, idx)}>
               <StyledTitle>
                 <h1>{title}</h1>
@@ -58,15 +61,27 @@ function NoteList() {
               </StyledTitle>
 
               <StyledNoteInfo>
-                <span>
-                  {date} &#183; {todo}
-                </span>
+                {date} &#183; {todo}
               </StyledNoteInfo>
             </div>
+
+            {noteStatus[idx] === 'open' && <BoardItem />}
           </StyledNote>
         ))}
       </StyledNoteList>
     </StyledRoot>
+  );
+}
+
+function BoardItem() {
+  return (
+    <StPinImageWrapper>
+      {Array.from({ length: 3 }, (_v, i) => i).map((idx) => (
+        <StImageWrapper key={idx} idx={idx}>
+          <div></div>
+        </StImageWrapper>
+      ))}
+    </StPinImageWrapper>
   );
 }
 
@@ -75,8 +90,8 @@ export default NoteList;
 const StyledRoot = styled.div`
   display: flex;
   flex-direction: column;
-  width: 33.8rem;
-  margin-left: 0.5rem;
+  width: 30.3rem;
+  margin: 0 2.1rem 0 0.5rem;
 `;
 
 const StyledCreateButton = styled(Link)`
@@ -107,9 +122,10 @@ const StyledNote = styled.div`
   display: flex;
   flex-direction: column;
   padding: 2rem 2.2rem;
+  margin-top: ${({ isOpen }) => isOpen && '2.2rem'};
   cursor: pointer;
-  ${({ status }) =>
-    status &&
+  ${({ isOpen }) =>
+    isOpen &&
     css`
       background-color: ${pinterestColors.gray100};
       border-bottom: none;
@@ -117,8 +133,8 @@ const StyledNote = styled.div`
     `}
 
   &:not(:last-child) {
-    border-bottom: ${({ status }) =>
-      !status ? '1.25px solid #e9e9e9' : '1.25px solid rgba(0,0,0,0)'};
+    border-bottom: ${({ isOpen }) =>
+      !isOpen ? '1.25px solid #e9e9e9' : '1.25px solid rgba(0,0,0,0)'};
   }
 `;
 
@@ -135,10 +151,35 @@ const StyledTitle = styled.div`
 
 const StyledNoteInfo = styled.div`
   display: flex;
-  & > span {
-    font-weight: 400;
-    font-size: 1.4rem;
-    line-height: 1.7rem;
-    color: ${pinterestColors.gray400};
-  }
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 1.7rem;
+  color: ${pinterestColors.gray400};
+`;
+
+const StPinImageWrapper = styled.article`
+  display: grid;
+  grid-template-columns: 16.8rem;
+  grid-template-rows: 9.5rem 9.3rem;
+  border-radius: 1rem;
+  overflow: hidden;
+  margin-top: 2.2rem;
+`;
+
+const StImageWrapper = styled.div`
+  height: 18.8rem;
+  background-color: #d9d9d9;
+
+  ${({ idx }) =>
+    idx === 1 &&
+    css`
+      grid-column: 2/3;
+      background-color: #a9a9a9;
+    `}
+  ${({ idx }) =>
+    idx === 2 &&
+    css`
+      grid-column: 2/3;
+      background-color: #c0c0c0;
+    `}
 `;

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useState } from 'react';
+import styled, { css } from 'styled-components';
 import { pinterestColors } from '../styles/color';
 import { ReactComponent as IPlus } from '../assets/iPlus.svg';
 import { ReactComponent as IOption } from '../assets/iOption.svg';
+import { Link } from 'react-router-dom';
 
 const noteList = [
   { title: '제목1', date: '2022년 11월 14일 (월)', todo: '할 일 2개' },
@@ -12,26 +13,39 @@ const noteList = [
 ];
 
 function NoteList() {
+  const [noteStatus, setNoteStatus] = useState(new Array(noteList.length).fill(false));
+  const toggleNoteStatus = (idx) => {
+    let newStatus = new Array(noteList.length).fill(false);
+    newStatus[idx] = !newStatus[idx];
+    setNoteStatus(newStatus);
+  };
+
   return (
     <StyledRoot>
-      <StyledCreateButton>
+      <StyledCreateButton to="/todo">
         <h1>노트 만들기</h1>
         <IPlus />
       </StyledCreateButton>
 
       <StyledNoteList>
-        {noteList.map((note) => (
-          <Note key={note.title} note={note} />
+        {noteList.map((note, idx) => (
+          <Note
+            key={note.title}
+            note={note}
+            noteStatus={noteStatus[idx]}
+            onClick={() => toggleNoteStatus(idx)}
+          />
         ))}
       </StyledNoteList>
     </StyledRoot>
   );
 }
 
-function Note({ note }) {
+function Note(props) {
+  const { note, noteStatus, onClick } = props;
   const { title, date, todo } = note;
   return (
-    <StyledNote>
+    <StyledNote onClick={onClick} status={noteStatus}>
       <StyledTitle>
         <h1>{title}</h1>
         <IOption />
@@ -51,10 +65,10 @@ const StyledRoot = styled.div`
   display: flex;
   flex-direction: column;
   width: 33.8rem;
-  overflow-y: scroll;
+  margin-left: 0.5rem;
 `;
 
-const StyledCreateButton = styled.div`
+const StyledCreateButton = styled(Link)`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -80,11 +94,18 @@ const StyledNoteList = styled.div`
 const StyledNote = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 0 2.2rem 2rem 2.2rem;
+  padding: ${({ status }) => (status ? '2rem 2.2rem' : '0 2.2rem 2rem 2.2rem')};
   cursor: pointer;
+  border-radius: 1.8rem;
+  ${({ status }) =>
+    status &&
+    css`
+      background-color: ${pinterestColors.gray100};
+      border-bottom: none;
+    `}
 
   &:not(:last-child) {
-    border-bottom: 1.25px solid #e9e9e9;
+    border-bottom: ${({ status }) => !status && '1.25px solid #e9e9e9'};
     margin-bottom: 1.6rem;
   }
 `;

--- a/src/components/NoteList.jsx
+++ b/src/components/NoteList.jsx
@@ -13,9 +13,11 @@ const noteList = [
   { title: '제목4', date: '2022년 11월 14일 (월)', todo: '할 일 2개' },
 ];
 
+const dropBoxData = { text: '노트 옵션', options: ['삭제', '수정'] };
+
 function NoteList() {
   const [noteStatus, setNoteStatus] = useState(new Array(noteList.length).fill(false));
-  const [openModal, setOpenModal] = useState(new Array(noteList.length).fill(false));
+  const [openDropBox, setOpenDropBox] = useState(new Array(noteList.length).fill(false));
 
   const toggleNoteStatus = (e, idx) => {
     if (e.target.closest('div').id === 'option') return;
@@ -23,12 +25,12 @@ function NoteList() {
   };
 
   const openOptionModal = (idx) => {
-    changeStatus(idx, openModal, setOpenModal);
+    changeStatus(idx, openDropBox, setOpenDropBox);
   };
 
   const changeStatus = (idx, array, handler) => {
     let newStatus = new Array(noteList.length).fill(false);
-    if (array.some((val) => val)) {
+    if (array.some((val) => val) && array.indexOf(true) === idx) {
       handler(newStatus);
       return;
     }
@@ -50,7 +52,7 @@ function NoteList() {
             onClick={(e) => toggleNoteStatus(e, idx)}
             status={noteStatus[idx]}
           >
-            {openModal[idx] && <DropBox />}
+            {openDropBox[idx] && <DropBox text={dropBoxData.text} options={dropBoxData.options} />}
             <StyledTitle>
               <h1>{title}</h1>
               <div id="option">
@@ -86,7 +88,7 @@ const StyledCreateButton = styled(Link)`
   padding: 1.6rem 2rem;
   border: 1px solid #efefef;
   border-radius: 1rem;
-  margin-bottom: 3rem;
+  margin-bottom: 1rem;
   cursor: pointer;
 
   & > h1 {
@@ -103,21 +105,21 @@ const StyledNoteList = styled.div`
 `;
 
 const StyledNote = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
-  padding: ${({ status }) => (status ? '2rem 2.2rem' : '0 2.2rem 2rem 2.2rem')};
+  padding: 2rem 2.2rem;
   cursor: pointer;
-  border-radius: 1.8rem;
   ${({ status }) =>
     status &&
     css`
       background-color: ${pinterestColors.gray100};
       border-bottom: none;
+      border-radius: 1.8rem;
     `}
 
   &:not(:last-child) {
     border-bottom: ${({ status }) => !status && '1.25px solid #e9e9e9'};
-    margin-bottom: 1.6rem;
   }
 `;
 

--- a/src/components/common/DropBox.jsx
+++ b/src/components/common/DropBox.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function DropBox() {
+  return <div>DropBox</div>;
+}
+
+export default DropBox;

--- a/src/components/common/DropBox.jsx
+++ b/src/components/common/DropBox.jsx
@@ -44,7 +44,11 @@ const StyledOption = styled.span`
   font-size: 1.6rem;
   line-height: 1.9rem;
   color: ${pinterestColors.black};
+  border-radius: 1.5rem;
   &:not(:last-child) {
     margin-bottom: 1.6rem;
+  }
+  &:hover {
+    background-color: ${pinterestColors.gray100};
   }
 `;

--- a/src/components/common/DropBox.jsx
+++ b/src/components/common/DropBox.jsx
@@ -1,7 +1,50 @@
 import React from 'react';
+import styled from 'styled-components';
+import { pinterestColors } from '../../styles/color';
 
-function DropBox() {
-  return <div>DropBox</div>;
+function DropBox(props) {
+  const { text, options } = props;
+
+  return (
+    <StyledRoot>
+      <StyledText>{text}</StyledText>
+      {options.map((option) => (
+        <StyledOption key={option}>{option}</StyledOption>
+      ))}
+    </StyledRoot>
+  );
 }
 
 export default DropBox;
+
+const StyledRoot = styled.div`
+  position: absolute;
+  top: 5.1rem;
+  right: -11rem;
+  display: flex;
+  flex-direction: column;
+  width: 18.1rem;
+  background: ${pinterestColors.white};
+  box-shadow: 0px 0px 3rem 0.4rem rgba(0, 0, 0, 0.06);
+  border-radius: 2rem;
+  padding: 2.2rem 2.4rem;
+  z-index: 9;
+`;
+
+const StyledText = styled.h1`
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 1.7rem;
+  color: ${pinterestColors.gray400};
+  margin-bottom: 1.6rem;
+`;
+
+const StyledOption = styled.span`
+  font-weight: 600;
+  font-size: 1.6rem;
+  line-height: 1.9rem;
+  color: ${pinterestColors.black};
+  &:not(:last-child) {
+    margin-bottom: 1.6rem;
+  }
+`;

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Header() {
+  return <div>Header</div>;
+}
+
+export default Header;

--- a/src/components/router.jsx
+++ b/src/components/router.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Header from './Header';
+import Header from '../components/common/Header';
 import Home from '../pages/Home';
 import Profile from '../pages/Profile';
 import Board from '../pages/Board';

--- a/src/pages/TODO.jsx
+++ b/src/pages/TODO.jsx
@@ -1,7 +1,30 @@
 import React from 'react';
+import styled from 'styled-components';
+import NoteList from '../components/NoteList';
 
 function TODO() {
-  return <div>TODO</div>;
+  return (
+    <StyledRoot>
+      <StyledTitle>제목</StyledTitle>
+      <StyledMain>
+        <NoteList />
+        <StyledNote>Note</StyledNote>
+      </StyledMain>
+    </StyledRoot>
+  );
 }
 
 export default TODO;
+
+const StyledRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledTitle = styled.h1``;
+
+const StyledMain = styled.main`
+  display: flex;
+`;
+
+const StyledNote = styled.article``;

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -52,4 +52,7 @@ export const GlobalStyle = createGlobalStyle`
     input[type="checkbox"]:checked::after {
         display: block;
     }
+    a{
+        text-decoration:none;
+    }
 `;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import svgr from 'vite-plugin-svgr';
+
+export default defineConfig({
+  plugins: [svgr(), react()],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
@@ -372,6 +372,108 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.3.tgz#953b88c20ea00d0eddaffdc1b115c08474aa295d"
   integrity sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==
 
+"@rollup/pluginutils@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
+  integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^2.3.1"
+
+"@svgr/babel-plugin-add-jsx-attribute@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz#74a5d648bd0347bda99d82409d87b8ca80b9a1ba"
+  integrity sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==
+
+"@svgr/babel-plugin-remove-jsx-attribute@*":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.5.0.tgz#652bfd4ed0a0699843585cda96faeb09d6e1306e"
+  integrity sha512-8zYdkym7qNyfXpWvu4yq46k41pyNM9SOstoWhKlm+IfdCE1DdnRKeMUPsWIEO/DEkaWxJ8T9esNdG3QwQ93jBA==
+
+"@svgr/babel-plugin-remove-jsx-empty-expression@*":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.5.0.tgz#4b78994ab7d39032c729903fc2dd5c0fa4565cb8"
+  integrity sha512-NFdxMq3xA42Kb1UbzCVxplUc0iqSyM9X8kopImvFnB+uSDdzIHOdbs1op8ofAvVRtbg4oZiyRl3fTYeKcOe9Iw==
+
+"@svgr/babel-plugin-replace-jsx-attribute-value@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.5.1.tgz#fb9d22ea26d2bc5e0a44b763d4c46d5d3f596c60"
+  integrity sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==
+
+"@svgr/babel-plugin-svg-dynamic-title@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.5.1.tgz#01b2024a2b53ffaa5efceaa0bf3e1d5a4c520ce4"
+  integrity sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==
+
+"@svgr/babel-plugin-svg-em-dimensions@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.5.1.tgz#dd3fa9f5b24eb4f93bcf121c3d40ff5facecb217"
+  integrity sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==
+
+"@svgr/babel-plugin-transform-react-native-svg@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.5.1.tgz#1d8e945a03df65b601551097d8f5e34351d3d305"
+  integrity sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==
+
+"@svgr/babel-plugin-transform-svg-component@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.5.1.tgz#48620b9e590e25ff95a80f811544218d27f8a250"
+  integrity sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==
+
+"@svgr/babel-preset@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-preset/-/babel-preset-6.5.1.tgz#b90de7979c8843c5c580c7e2ec71f024b49eb828"
+  integrity sha512-6127fvO/FF2oi5EzSQOAjo1LE3OtNVh11R+/8FXa+mHx1ptAaS4cknIjnUA7e6j6fwGGJ17NzaTJFUwOV2zwCw==
+  dependencies:
+    "@svgr/babel-plugin-add-jsx-attribute" "^6.5.1"
+    "@svgr/babel-plugin-remove-jsx-attribute" "*"
+    "@svgr/babel-plugin-remove-jsx-empty-expression" "*"
+    "@svgr/babel-plugin-replace-jsx-attribute-value" "^6.5.1"
+    "@svgr/babel-plugin-svg-dynamic-title" "^6.5.1"
+    "@svgr/babel-plugin-svg-em-dimensions" "^6.5.1"
+    "@svgr/babel-plugin-transform-react-native-svg" "^6.5.1"
+    "@svgr/babel-plugin-transform-svg-component" "^6.5.1"
+
+"@svgr/core@^6.4.0":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/core/-/core-6.5.1.tgz#d3e8aa9dbe3fbd747f9ee4282c1c77a27410488a"
+  integrity sha512-/xdLSWxK5QkqG524ONSjvg3V/FkNyCv538OIBdQqPNaAta3AsXj/Bd2FbvR87yMbXO2hFSWiAe/Q6IkVPDw+mw==
+  dependencies:
+    "@babel/core" "^7.19.6"
+    "@svgr/babel-preset" "^6.5.1"
+    "@svgr/plugin-jsx" "^6.5.1"
+    camelcase "^6.2.0"
+    cosmiconfig "^7.0.1"
+
+"@svgr/hast-util-to-babel-ast@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-6.5.1.tgz#81800bd09b5bcdb968bf6ee7c863d2288fdb80d2"
+  integrity sha512-1hnUxxjd83EAxbL4a0JDJoD3Dao3hmjvyvyEV8PzWmLK3B9m9NPlW7GKjFyoWE8nM7HnXzPcmmSyOW8yOddSXw==
+  dependencies:
+    "@babel/types" "^7.20.0"
+    entities "^4.4.0"
+
+"@svgr/plugin-jsx@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@svgr/plugin-jsx/-/plugin-jsx-6.5.1.tgz#0e30d1878e771ca753c94e69581c7971542a7072"
+  integrity sha512-+UdQxI3jgtSjCykNSlEMuy1jSRQlGC7pqBCPvkG/2dATdWo082zHTTK3uhnAju2/6XpE6B5mZ3z4Z8Ns01S8Gw==
+  dependencies:
+    "@babel/core" "^7.19.6"
+    "@svgr/babel-preset" "^6.5.1"
+    "@svgr/hast-util-to-babel-ast" "^6.5.1"
+    svg-parser "^2.0.4"
+
+"@types/estree@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
+  integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
+
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
 "@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
@@ -579,6 +681,11 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase@^6.2.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
 camelize@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
@@ -685,6 +792,17 @@ convert-source-map@^1.7.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
+cosmiconfig@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -771,6 +889,18 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+entities@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
 
 es-abstract@^1.19.0, es-abstract@^1.20.4:
   version "1.20.4"
@@ -1091,6 +1221,11 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -1383,6 +1518,11 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
 is-bigint@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
@@ -1529,6 +1669,11 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -1564,6 +1709,11 @@ lilconfig@2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.5.tgz#19e57fd06ccc3848fd1891655b5a447092225b25"
   integrity sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==
+
+lines-and-columns@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 lint-staged@^13.0.3:
   version "13.0.3"
@@ -1834,6 +1984,16 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-json@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -1858,6 +2018,11 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -2259,6 +2424,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svg-parser@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
+  integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2328,6 +2498,14 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+vite-plugin-svgr@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/vite-plugin-svgr/-/vite-plugin-svgr-2.2.2.tgz#c5c9cb573bf455bb079550531847ddc5d2e122af"
+  integrity sha512-u8Ac27uZmDHTVGawpAhvLMJMuzbGeZGhe61TGeHoRQLxVhmQfIYCefa0iLbjC0ui1zFo6XZnS8EkzPITCYp85g==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.0"
+    "@svgr/core" "^6.4.0"
+
 vite@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/vite/-/vite-3.2.3.tgz#7a68d9ef73eff7ee6dc0718ad3507adfc86944a7"
@@ -2385,6 +2563,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.1.1:
   version "2.1.3"


### PR DESCRIPTION
## ⛓ Related Issues
- close #7 

## 📋 작업 내용
- [x] ~ 좌측 노트 영역 구현
- [x] ~ App.jsx 감싸는 Layout 생성 -> 화면 양쪽 margin 주기 위함 (사진참조)
![image](https://user-images.githubusercontent.com/66051416/202075133-28fa461c-b22e-4e53-9d3a-d73557c6646a.png)
- [x] ~ 수정, 삭제 드롭박스 구현

## 📌 PR Point
<!-- 무슨 이유로 어떻게 코드를 변경했는지-->
<!--어떤 위험이나 우려가 발견되었는지-->
<!--어떤 부분에 리뷰어가 집중해야 하는지-->
- NoteList.jsx 내부에 `BoardItem` 컴포넌트를 분리 안하고 한 파일 안에서 임의로 작성했는데, 나중에 Profile 페이지에서도 요 컴포넌트를 쓰게 되면 따로 파일로 분리해서 쓰면 될 것 같아요. 지금은 안이 텅 빈 div 태그로 UI만 구현해놨고, Profile 페이지 작업자(@R1mmm )가 안에 이미지 들어갈 수 있게 수정해주시면 좋을 것 같아요! 
```jsx
// ...  NoteList.jsx ...

function BoardItem() {
  return (
    <StyledBoardItemWrapper>
      {Array.from({ length: 3 }, (_v, i) => i).map((idx) => (
        <StyledBoardItem key={idx} idx={idx}>
          <div></div>
        </StyledBoardItem>
      ))}
    </StyledBoardItemWrapper>
  );
}
```

## 👀 스크린샷 / GIF / 링크
![image](https://user-images.githubusercontent.com/66051416/202074969-e857eefc-d31c-4e3d-9a63-3861efc5a86e.png)


## 🔬 Reference
<!-- 필요하면 작성하고 없으면 지워주세요 -->
- 구현에 참고한 링크
