### PR TITLE
Feat/#35 Profile 보드아이템 navigation 작업

### DIFF
--- a/src/components/profile/PinList.jsx
+++ b/src/components/profile/PinList.jsx
@@ -1,16 +1,16 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { default as icDrop } from '../../assets/icon_drop.svg';
 import DropBox from '../../components/common/DropBox';
 import { pinterestColors } from '../../styles/color';
 import BoardItem from '../common/BoardItem';
-import { boardData, board1_pinData, board2_pinData } from './testData.js';
 import { getBoards } from '../../services';
 
 const dropBoxData = { text: '정렬 기준', options: ['알파벳순', '사용자 지정', '마지막 저장일'] };
-const test = [1, 1, 1, 1, 1];
 
 function PinList() {
+  const navigate = useNavigate();
   const [boards, setBoards] = useState(null);
   const [openModal, setOpenModal] = useState(false);
 
@@ -42,28 +42,29 @@ function PinList() {
       <StyledPinWrapper>
         <StyledBoardWrapper>
           <StyledFirstBoard>
-            {boards[0]?.pins.slice(0, 5).map((item, index) => (
-              <StyledFirstPins key={index} idx={index}>
-                <img src={item.imageUrl}></img>
-              </StyledFirstPins>
-            ))}
+            {boards !== null &&
+              boards[0].pins.slice(0, 5).map((item, index) => (
+                <StyledFirstPins key={index} idx={index}>
+                  <img src={item.imageUrl}></img>
+                </StyledFirstPins>
+              ))}
           </StyledFirstBoard>
           <StyledBoardTitle>
             모든 핀
             <p>
-              핀 n개 <span>n주</span>
+              핀 22개 <span>1주</span>
             </p>
           </StyledBoardTitle>
         </StyledBoardWrapper>
         {boards?.map((board, index) => (
           <StyledBoardWrapper key={index}>
-            <div>
+            <div onClick={() => navigate(`/board/${board.uid}`)}>
               <BoardItem status="profile" pins={board.pins} />
             </div>
             <StyledBoardTitle>
               {board.title}
               <p>
-                핀 {board.pins?.length}개 <span>n주</span>
+                핀 {board.pins?.length}개 <span>2주</span>
               </p>
             </StyledBoardTitle>
           </StyledBoardWrapper>
@@ -209,4 +210,7 @@ const StyledBoardWrapper = styled.div`
   width: 23rem;
   margin-right: 2rem;
   position: relative;
+  div:first-child {
+    cursor: pointer;
+  }
 `;

--- a/src/components/router.jsx
+++ b/src/components/router.jsx
@@ -14,7 +14,7 @@ function Router() {
         <Routes>
           <Route path="/" element={<Home />}></Route>
           <Route path="/profile" element={<Profile />}></Route>
-          <Route path="/board" element={<Board />}></Route>
+          <Route path="/board/:uid" element={<Board />}></Route>
           <Route path="/todo" element={<Todo />}></Route>
         </Routes>
       </BrowserRouter>


### PR DESCRIPTION
## ⛓ Related Issues
- close #35 

## 📋 작업 내용
- [x] profile에서 보드 클릭시, 해당 보드 id가 담긴 url로 이동하게 해주었습니다.

## 📌 PR Point

router.jsx에 Board 컴포넌트를 보여주는 path를 board/:uid 로 변경했습니다(서버에서 보내주는 데이터에서 uid가 보드고유id를 뜻해서..!)
```
function Router() {
  return (
    <>
      <BrowserRouter>
        <Header />
        <Routes>
          <Route path="/" element={<Home />}></Route>
          <Route path="/profile" element={<Profile />}></Route>
          <Route path="/board/:uid" element={<Board />}></Route>
          <Route path="/todo" element={<Todo />}></Route>
        </Routes>
      </BrowserRouter>
    </>
  );
}
```

예원언니가 쓸 때엔 
```
import { useParams } from 'react-router-dom';

const test = () => {
  const { params } = useParams();

```
요렇게 params 에 보드 고유 id 가 담기게해서 사용할 수 있을듯 해요!

## 👀 스크린샷 / GIF / 링크
![sssss](https://user-images.githubusercontent.com/87795291/203784077-a5966b5d-012d-43b6-a99a-d2587e19843e.gif)
